### PR TITLE
impr: RELENG-7322 docker-build: add label 'git.commit'

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -15,6 +15,12 @@ on:
         required: false
         type: string
         default: "${{ github.sha }}"
+      labels:
+        required: false
+        type: string
+        default: |
+          git.repository=${{ github.repository }}
+          git.commit-sha=${{ github.sha }}
       registry:
         required: false
         type: string
@@ -81,6 +87,7 @@ jobs:
         provenance: ${{ inputs.provenance }}
         push: ${{ inputs.push }}
         tags: ${{ inputs.registry }}/${{ inputs.namespace }}/${{ inputs.name }}:${{ inputs.tag }}
+        labels: ${{ inputs.labels }}
         cache-from: type=gha,scope=${{ inputs.name }}
         cache-to: type=gha,mode=max,scope=${{ inputs.name }}
         no-cache: ${{ inputs.no-cache }}


### PR DESCRIPTION
Add the label 'git.commit' to images built using the docker-build workflow, which value is the git commit hash of the image.

The immediate need is for Integration to tell which commit hash to pull Cloudserver tests from (INTGR-907).