### PR TITLE
Change default provenance to true

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -51,7 +51,7 @@ on:
       provenance:
         required: false
         type: boolean
-        default: false
+        default: true
     secrets:
       REGISTRY_LOGIN:
         required: false


### PR DESCRIPTION
Docker build workflow default parameter provenance now set to `true`