### PR TITLE
Fix dependency review workflow for Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-dependency-review.yml
+++ b/.github/workflows/claude-code-dependency-review.yml
@@ -28,6 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
 
       - name: Install dependencies

--- a/.github/workflows/claude-code-dependency-review.yml
+++ b/.github/workflows/claude-code-dependency-review.yml
@@ -32,6 +32,8 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
+      checks: read
+      actions: read
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/claude-code-dependency-review.yml
+++ b/.github/workflows/claude-code-dependency-review.yml
@@ -15,6 +15,14 @@ on:
       CLOUD_ML_REGION:
         required: true
         description: GCP region for Vertex AI
+      ACTIONS_APP_PRIVATE_KEY:
+        required: false
+        description: Private key for the GitHub App used to access private repositories
+    inputs:
+      ACTIONS_APP_ID:
+        required: false
+        type: string
+        description: App ID for the GitHub App used to access private repositories
 
 jobs:
   dependency-review:
@@ -30,6 +38,22 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
+
+      - name: Generate token for private repositories
+        if: inputs.ACTIONS_APP_ID != ''
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ inputs.ACTIONS_APP_ID }}
+          private-key: ${{ secrets.ACTIONS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Configure git for private repositories
+        if: steps.app-token.outputs.token != ''
+        run: |
+          git config --global url."https://x-access-token:${GIT_ACCESS_TOKEN}@github.com/".insteadOf "https://github.com/"
+        env:
+          GIT_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Install dependencies
         id: install-deps

--- a/.github/workflows/claude-code-dependency-review.yml
+++ b/.github/workflows/claude-code-dependency-review.yml
@@ -54,7 +54,7 @@ jobs:
           github_token: ${{ github.token }}
           use_vertex: "true"
           allowed_bots: "dependabot[bot]"
-          plugin_marketplaces: https://github.com/scality/agent-hub
+          plugin_marketplaces: https://github.com/scality/agent-hub.git
           plugins: scality-skills@scality-agent-hub
           prompt: "/review-dependency-bump REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}"
           claude_args: |

--- a/.github/workflows/claude-code-dependency-review.yml
+++ b/.github/workflows/claude-code-dependency-review.yml
@@ -23,6 +23,11 @@ on:
         required: false
         type: string
         description: App ID for the GitHub App used to access private repositories
+      node-version:
+        required: false
+        type: string
+        default: '22'
+        description: Node.js version to use for dependency installation
 
 jobs:
   dependency-review:
@@ -57,11 +62,17 @@ jobs:
         env:
           GIT_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
 
+      - name: Set up Node.js
+        if: hashFiles('yarn.lock') != ''
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+
       - name: Install dependencies
         id: install-deps
         if: hashFiles('yarn.lock') != ''
         continue-on-error: true
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --ignore-scripts
 
       - name: Warn on failed dependency install
         if: steps.install-deps.outcome == 'failure'

--- a/.github/workflows/claude-code-dependency-review.yml
+++ b/.github/workflows/claude-code-dependency-review.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           github_token: ${{ github.token }}
           use_vertex: "true"
+          allowed_bots: "dependabot[bot]"
           plugin_marketplaces: https://github.com/scality/agent-hub
           plugins: scality-skills@scality-agent-hub
           prompt: "/review-dependency-bump REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}"


### PR DESCRIPTION
- Checkout PR head commit: `pull_request_target` checks out the base branch by default. We need to pass `ref` to ` actions/checkout` so the review can analyze PR's changes
- Allow Dependabot as bot actor: `claude-code-action` rejects bot-initiated triggers by default; add `dependabot[bot]` to `allowed_bots`
- Fix plugin marketplace URL: `claude-code-action` validates that marketplace URLs end with `.git`
- Configure git credentials for private repos* Accept an optional `GIT_ACCESS_TOKEN` secret so yarn can install private Scality dependencies and the action can clone the private agent-hub plugin marketplace