### PR TITLE
feat: add capability to skip AI review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,6 +2,11 @@ name: Claude Code Review
 
 on:
   workflow_call:
+    inputs:
+      skip_label:
+        type: string
+        description: "If this label is set on the PR, the review will be skipped"
+        default: "skip-claude-review"
     secrets:
       GCP_WORKLOAD_IDENTITY_PROVIDER:
         required: true
@@ -18,6 +23,7 @@ on:
 
 jobs:
   claude-review:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, inputs.skip_label) }}
     runs-on: ubuntu-latest
     timeout-minutes: 15  # adds cost protection
     permissions:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -2,7 +2,7 @@ name: Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, labeled, unlabeled]
   pull_request_target:
     types: [opened, synchronize]
 


### PR DESCRIPTION
Adds a `skip_label` input (default: `skip-claude-review`) to the `claude-code-review` reusable workflow. When that label is present on a PR, the Claude review job is skipped.

Adding or removing the label on an open PR also re-triggers the workflow, thanks to the new `labeled`/`unlabeled` event types on the `pull_request` trigger.

Callers can override the label name via `with: skip_label: <label>`.