### PR TITLE
ci: update GitHub Actions to Node 24 runtime

### DIFF
--- a/.github/workflows/claude-code-dependency-review.yml
+++ b/.github/workflows/claude-code-dependency-review.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Set up Node.js
         if: hashFiles('yarn.lock') != ''
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
 

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -86,17 +86,17 @@ jobs:
       if: inputs.platforms
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Login to ${{ inputs.registry }}
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ inputs.registry }}
         username: ${{ env.REGISTRY_LOGIN }}
         password: ${{ env.REGISTRY_PASSWORD }}
 
     - name: Build and push ${{ inputs.name }} image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: ${{ inputs.context }}
         provenance: ${{ inputs.provenance }}

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -77,12 +77,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         lfs: ${{ inputs.lfs }}
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4
       if: inputs.platforms
 
     - name: Set up Docker Buildx

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -50,7 +50,7 @@ jobs:
           vuln-type: 'os,library'
 
       - name: Upload Trivy Image scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-image-results.sarif'
           category: 'image'

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Image Scan
         uses: aquasecurity/trivy-action@0.35.0


### PR DESCRIPTION
## Summary
- Update GitHub Actions action versions to support Node 24 runtime
- Bumps checkout, setup-node, upload-artifact, download-artifact, cache, docker actions, codecov, codeql, and other actions to their latest versions

## Test plan
- [ ] Verify CI workflows run successfully after the action version bumps