### PR TITLE
Restrict allowedTools to prevent approvals and broad API access

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -51,7 +51,7 @@ jobs:
           use_vertex: "true"
           prompt: "/review-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}"
           claude_args: |
-            --allowedTools "Read" "Bash(git diff *)" "Bash(git log *)" "Bash(git show *)" "Bash(gh repo view *)" "Bash(gh pr view *)" "Bash(gh pr diff *)" "Bash(gh pr comment *)" "Bash(gh api *)" "Bash(gh pr checks *)"
+            --allowedTools "Read" "Bash(git diff *)" "Bash(git log *)" "Bash(git show *)" "Bash(gh repo view *)" "Bash(gh pr view *)" "Bash(gh pr diff *)" "Bash(gh pr checks *)" "Bash(gh pr comment *)" "Bash(gh api *repos/*/pulls/*/comments*)" "Bash(gh api *issues/*/comments*)" "Bash(gh api *repos/*/check-runs*)"
             --model "claude-opus-4-6"
         env:
           ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.ANTHROPIC_VERTEX_PROJECT_ID }}


### PR DESCRIPTION
Replace the broad "Bash(gh api *)" allow rule with three narrow
patterns that match only the endpoints the review skills actually use:
pulls/*/comments (inline comments), issues/*/comments (summary
comments), and check-runs (check run create/update).

The broad rule allowed Claude to POST to .../pulls/<n>/reviews, which
is the approval endpoint. Narrowing it closes that path while still
supporting both review styles (inline + check run, inline + summary
comment) across consuming repos.

Issue: SOR-238
