### PR TITLE
Make claude-code-review workflow configurable

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,6 +11,10 @@ on:
         type: string
         description: Claude model to use for the review
         default: claude-opus-4-6
+      plugins:
+        type: string
+        description: Comma-separated list of skills to use from the agent hub (e.g. scality-skills@scality-agent-hub)
+        default: scality-skills@scality-agent-hub
     secrets:
       GCP_WORKLOAD_IDENTITY_PROVIDER:
         required: true
@@ -57,6 +61,8 @@ jobs:
           claude_args: |
             --allowedTools "Read" "Bash(git diff *)" "Bash(git log *)" "Bash(git show *)" "Bash(gh repo view *)" "Bash(gh pr view *)" "Bash(gh pr diff *)" "Bash(gh pr checks *)" "Bash(gh pr comment *)" "Bash(gh api *repos/*/pulls/*/comments*)" "Bash(gh api *issues/*/comments*)" "Bash(gh api *repos/*/check-runs*)"
             --model "${{ inputs.model }}"
+          plugin_marketplaces: scality/agent-hub
+          plugins: ${{ inputs.plugins }}
         env:
           ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.ANTHROPIC_VERTEX_PROJECT_ID }}
           CLOUD_ML_REGION: ${{ secrets.CLOUD_ML_REGION }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -7,6 +7,10 @@ on:
         type: string
         description: "If this label is set on the PR, the review will be skipped"
         default: "skip-claude-review"
+      model:
+        type: string
+        description: Claude model to use for the review
+        default: claude-opus-4-6
     secrets:
       GCP_WORKLOAD_IDENTITY_PROVIDER:
         required: true
@@ -52,7 +56,7 @@ jobs:
           prompt: "/review-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}"
           claude_args: |
             --allowedTools "Read" "Bash(git diff *)" "Bash(git log *)" "Bash(git show *)" "Bash(gh repo view *)" "Bash(gh pr view *)" "Bash(gh pr diff *)" "Bash(gh pr checks *)" "Bash(gh pr comment *)" "Bash(gh api *repos/*/pulls/*/comments*)" "Bash(gh api *issues/*/comments*)" "Bash(gh api *repos/*/check-runs*)"
-            --model "claude-opus-4-6"
+            --model "${{ inputs.model }}"
         env:
           ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.ANTHROPIC_VERTEX_PROJECT_ID }}
           CLOUD_ML_REGION: ${{ secrets.CLOUD_ML_REGION }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,6 +15,14 @@ on:
         type: string
         description: Comma-separated list of skills to use from the agent hub (e.g. scality-skills@scality-agent-hub)
         default: scality-skills@scality-agent-hub
+      summary-mode:
+        type: string
+        description: >
+          How the review output should be posted:
+          - check: post as a check run (requires checks: write permission)
+          - comment: post as a PR comment
+          - auto: check if allowed, otherwise post as a comment
+        default: auto
     secrets:
       GCP_WORKLOAD_IDENTITY_PROVIDER:
         required: true
@@ -63,6 +71,9 @@ jobs:
             --model "${{ inputs.model }}"
           plugin_marketplaces: scality/agent-hub
           plugins: ${{ inputs.plugins }}
+          additional_permissions: |
+            ${{ inputs.summary-mode != 'comment' && 'checks: write' || '' }}
         env:
           ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.ANTHROPIC_VERTEX_PROJECT_ID }}
           CLOUD_ML_REGION: ${{ secrets.CLOUD_ML_REGION }}
+          PUBLISH_MODE: ${{ inputs.summary-mode }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,14 +31,24 @@ on:
           - comment: post as a PR comment
           - auto: check if allowed, otherwise post as a comment
         default: auto
-      ACTIONS_APP_ID:
+      allowed-tools:
         type: string
         description: >
-          GitHub App ID used to generate a token for checking out marketplace
-          repositories at a specific branch. Required when any entry in
-          plugin_marketplaces uses the `<url>#<ref>` syntax.
-        required: false
-        default: ${{ vars.ACTIONS_APP_ID }}
+          Space-separated list of allowed tools for the review. By default, a set of safe tools is allowed, but you can customize this list to enable or disable specific tools based on your needs and risk tolerance.
+          NOTE: should not be needed if the skill already indicates the appropriate allowed tools. Keeping default value for compatibility.
+        default: >-
+          "Read"
+          "Bash(git diff *)"
+          "Bash(git log *)"
+          "Bash(git show *)"
+          "Bash(gh repo view *)"
+          "Bash(gh pr view *)"
+          "Bash(gh pr diff *)"
+          "Bash(gh pr checks *)"
+          "Bash(gh pr comment *)"
+          "Bash(gh api *repos/*/pulls/*/comments*)"
+          "Bash(gh api *issues/*/comments*)"
+          "Bash(gh api *repos/*/check-runs*)"
     secrets:
       GCP_WORKLOAD_IDENTITY_PROVIDER:
         required: true
@@ -137,7 +147,7 @@ jobs:
           use_vertex: "true"
           prompt: "/review-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}"
           claude_args: |
-            --allowedTools "Read" "Bash(git diff *)" "Bash(git log *)" "Bash(git show *)" "Bash(gh repo view *)" "Bash(gh pr view *)" "Bash(gh pr diff *)" "Bash(gh pr checks *)" "Bash(gh pr comment *)" "Bash(gh api *repos/*/pulls/*/comments*)" "Bash(gh api *issues/*/comments*)" "Bash(gh api *repos/*/check-runs*)"
+            --allowedTools ${{ inputs.allowed-tools }}
             --model "${{ inputs.model }}"
           plugin_marketplaces: ${{ steps.marketplaces.outputs.marketplaces }}
           plugins: ${{ inputs.plugins }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,6 +15,14 @@ on:
         type: string
         description: Comma-separated list of skills to use from the agent hub (e.g. scality-skills@scality-agent-hub)
         default: scality-skills@scality-agent-hub
+      plugin_marketplaces:
+        type: string
+        description: |
+          Marketplace to pull plugin from. Defaults to agent-hub, but possible to use another repo
+          or branch of the marketplace to pull the skills from (e.g. main):
+            https://github.com/scality/agent-hub.git#<my-branch>
+          Especially useful for testing a new version of a skill before it's merged to the default branch.
+        default: scality/agent-hub
       summary-mode:
         type: string
         description: >
@@ -23,6 +31,14 @@ on:
           - comment: post as a PR comment
           - auto: check if allowed, otherwise post as a comment
         default: auto
+      ACTIONS_APP_ID:
+        type: string
+        description: >
+          GitHub App ID used to generate a token for checking out marketplace
+          repositories at a specific branch. Required when any entry in
+          plugin_marketplaces uses the `<url>#<ref>` syntax.
+        required: false
+        default: ${{ vars.ACTIONS_APP_ID }}
     secrets:
       GCP_WORKLOAD_IDENTITY_PROVIDER:
         required: true
@@ -36,6 +52,9 @@ on:
       CLOUD_ML_REGION:
         required: true
         description: GCP region for Vertex AI
+      ACTIONS_APP_PRIVATE_KEY:
+        required: false
+        description: Private key of the GitHub App used to check out marketplace repositories
 
 jobs:
   claude-review:
@@ -53,6 +72,57 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Identify marketplaces needing local checkout
+        id: marketplaces
+        uses: actions/github-script@v7
+        env:
+          PLUGIN_MARKETPLACES: ${{ inputs.plugin_marketplaces }}
+        with:
+          script: |
+            // Entries using `<url>#<ref>` syntax are not supported natively by
+            // the claude-code plugin loader. Extract them so we can clone the
+            // repo locally and substitute the entry with the local path.
+            const entryPattern = /^(?:https?:\/\/github\.com\/)?([^/#]+)\/([^/#]+?)(?:\.git)?#(.+)$/;
+            const checkouts = [];
+            const marketplaces = (process.env.PLUGIN_MARKETPLACES || '').split(/[,\n]/).map(entry => {
+                const m = entry.trim().match(entryPattern);
+                if (!m) {
+                  return entry;
+                }
+
+              const [, owner, repo, ref] = m;
+              const path = `.marketplaces/${owner}-${repo}`;
+              checkouts.push({ repository: `${owner}/${repo}`, repo, ref, path });
+
+              return `./${path}`;
+            });
+            core.setOutput('checkouts', JSON.stringify(checkouts));
+            core.setOutput('repositories', checkouts.map(c => c.repo).join('\n'));
+            core.setOutput('marketplaces', marketplaces.join('\n'));
+
+      - name: Get token for marketplace repositories
+        if: steps.marketplaces.outputs.repositories != ''
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.ACTIONS_APP_ID }}
+          private-key: ${{ secrets.ACTIONS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ steps.marketplaces.outputs.repositories }}
+
+      - name: Checkout marketplace repositories
+        if: steps.marketplaces.outputs.repositories != ''
+        env:
+          CHECKOUTS: ${{ steps.marketplaces.outputs.checkouts }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          jq -r '.[] | [.repository, .ref, .path] | @tsv' <<< "$CHECKOUTS" | while IFS=$'\t' read -r repo ref path; do
+            git clone --depth 1 --branch "$ref" "https://x-access-token:${GH_TOKEN}@github.com/${repo}.git" "$path"
+
+            # remove token from git config
+            git -C "$path" remote remove origin
+          done
+
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
@@ -69,7 +139,7 @@ jobs:
           claude_args: |
             --allowedTools "Read" "Bash(git diff *)" "Bash(git log *)" "Bash(git show *)" "Bash(gh repo view *)" "Bash(gh pr view *)" "Bash(gh pr diff *)" "Bash(gh pr checks *)" "Bash(gh pr comment *)" "Bash(gh api *repos/*/pulls/*/comments*)" "Bash(gh api *issues/*/comments*)" "Bash(gh api *repos/*/check-runs*)"
             --model "${{ inputs.model }}"
-          plugin_marketplaces: scality/agent-hub
+          plugin_marketplaces: ${{ steps.marketplaces.outputs.marketplaces }}
           plugins: ${{ inputs.plugins }}
           additional_permissions: |
             ${{ inputs.summary-mode != 'comment' && 'checks: write' || '' }}


### PR DESCRIPTION
Improve the claude-code-review workflow to be configurable:
- make model configurable
- use review-pr skill from agent-hub as fallback, if not present in the repo
- configure summary mode (for agent-hub's review-pr skill)
- allow specifying marketplace branch, to simplify testing changes
- allow configuring `allowedTools`. These are actually not required in the workflow, as they are already in the skill;
however keep them for compatibility with already deployed skills.

Testing changes from the agent-hub can be done quite easily, for exemple the following script in zenko uses both the workflow and agent-hub PRs. It can even be triggered manually on another PR -which is why we need the extra allowed-tools- for testing:

```yaml
name: Code Review
run-name: 'Code Review for #${{ github.event.pull_request.number || inputs.pr_number }}${{ github.event.pull_request.title && format('' : {0}'', github.event.pull_request.title) }}'

on:
  pull_request:
    types: [opened, synchronize]
  workflow_dispatch:
    inputs:
      pr_number:
        description: Pull Request number to review
        required: true

jobs:
  review:
    uses: scality/workflows/.github/workflows/claude-code-review.yml@improvement/ZENKO-5260 #v2.7.0
    with:
      plugin_marketplaces: https://github.com/scality/agent-hub.git#improvement/ZENKO-5260
      allowed-tools: >-
        "Bash(gh api repos/*/content)"
    secrets:
      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
      GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
      ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.ANTHROPIC_VERTEX_PROJECT_ID }}
      CLOUD_ML_REGION: ${{ secrets.CLOUD_ML_REGION }}
      ACTIONS_APP_PRIVATE_KEY: ${{ secrets.ACTIONS_APP_PRIVATE_KEY }}
```

Issue: ZENKO-5260
