### PR TITLE
Fix invalid default plugin_marketplaces URL format in claude-code-review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,7 +22,7 @@ on:
           or branch of the marketplace to pull the skills from (e.g. main):
             https://github.com/scality/agent-hub.git#<my-branch>
           Especially useful for testing a new version of a skill before it's merged to the default branch.
-        default: scality/agent-hub
+        default: https://github.com/scality/agent-hub.git
       summary-mode:
         type: string
         description: >


### PR DESCRIPTION
The plugin_marketplaces input introduced in PR #101 has a default value of scality/agent-hub, which is an owner/repo shorthand. The claude-code-action validation requires marketplace URLs to start with https:// and end with .git. Since the bare shorthand matches neither, the action rejects it with "Invalid marketplace URL format: scality/agent-hub".