### PR TITLE
Let action degrade nicely when secrets are missing

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -87,8 +87,20 @@ jobs:
         uses: actions/github-script@v7
         env:
           PLUGIN_MARKETPLACES: ${{ inputs.plugin_marketplaces }}
+          PLUGINS: ${{ inputs.plugins }}
+          HAS_APP_KEY: ${{ secrets.ACTIONS_APP_PRIVATE_KEY != '' }}
         with:
           script: |
+            const hasAppKey = process.env.HAS_APP_KEY === 'true';
+            if (!hasAppKey) {
+              core.warning('ACTIONS_APP_PRIVATE_KEY secret is not set; skipping plugin marketplaces and plugins.');
+              core.setOutput('checkouts', '[]');
+              core.setOutput('repositories', '');
+              core.setOutput('marketplaces', '');
+              core.setOutput('plugins', '');
+              return;
+            }
+
             // Entries using `<url>#<ref>` syntax are not supported natively by
             // the claude-code plugin loader. Extract them so we can clone the
             // repo locally and substitute the entry with the local path.
@@ -106,9 +118,11 @@ jobs:
 
               return `./${path}`;
             });
+
             core.setOutput('checkouts', JSON.stringify(checkouts));
             core.setOutput('repositories', checkouts.map(c => c.repo).join('\n'));
             core.setOutput('marketplaces', marketplaces.join('\n'));
+            core.setOutput('plugins', process.env.PLUGINS || '');
 
       - name: Get token for marketplace repositories
         if: steps.marketplaces.outputs.repositories != ''
@@ -150,7 +164,7 @@ jobs:
             --allowedTools ${{ inputs.allowed-tools }}
             --model "${{ inputs.model }}"
           plugin_marketplaces: ${{ steps.marketplaces.outputs.marketplaces }}
-          plugins: ${{ inputs.plugins }}
+          plugins: ${{ steps.marketplaces.outputs.plugins }}
           additional_permissions: |
             ${{ inputs.summary-mode != 'comment' && 'checks: write' || '' }}
         env:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -10,19 +10,9 @@ jobs:
   review:
     if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     uses: ./.github/workflows/claude-code-review.yml
-    secrets:
-      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-      GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.ANTHROPIC_VERTEX_PROJECT_ID }}
-      CLOUD_ML_REGION: ${{ secrets.CLOUD_ML_REGION }}
-      ACTIONS_APP_PRIVATE_KEY: ${{ secrets.ACTIONS_APP_PRIVATE_KEY }}
+    secrets: inherit
 
   review-dependency-bump:
     if: github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]'
     uses: ./.github/workflows/claude-code-dependency-review.yml
-    secrets:
-      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-      GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.ANTHROPIC_VERTEX_PROJECT_ID }}
-      CLOUD_ML_REGION: ${{ secrets.CLOUD_ML_REGION }}
-      ACTIONS_APP_PRIVATE_KEY: ${{ secrets.ACTIONS_APP_PRIVATE_KEY }}
+    secrets: inherit

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,22 @@
 # Workflows
 
 This repository is used to share GitHub Actions reusable workflows across the organization.
+
+## Calling conventions
+
+When calling any workflow from this repository, prefer `secrets: inherit` over listing
+secrets explicitly:
+
+```yaml
+jobs:
+  docker-build:
+    uses: scality/workflows/.github/workflows/docker-build.yaml@v2
+    with:
+      name: my-image
+    secrets: inherit
+```
+
+This way, if a reusable workflow starts requiring a new secret, consuming repos pick it
+up automatically instead of silently breaking until each caller is patched. Only fall
+back to explicit `secrets:` mapping when the caller's secret name does not match the
+name expected by the reusable workflow.


### PR DESCRIPTION
`ACTIONS_APP_PRIVATE_KEY` secret is required to use agent-hub; for compatibiltiy with existing deployments, fall back to the old behavior (no marketplace, no plugin) if that secret is not available.

Also recomend inheriting secrets for these actions to minimize frictions. Should be safe, since this action is used in the organization and most -if not all- secrets are organization-scoped anyway.

Issue: ZENKO-5260
