### PR TITLE
fix: allow Renovate as a bot in dependency reviews

### DIFF
--- a/.github/workflows/claude-code-dependency-review.yml
+++ b/.github/workflows/claude-code-dependency-review.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           github_token: ${{ github.token }}
           use_vertex: "true"
-          allowed_bots: "dependabot[bot]"
+          allowed_bots: "dependabot[bot], scality-renovate[bot]"
           plugin_marketplaces: https://github.com/scality/agent-hub.git
           plugins: scality-skills@scality-agent-hub
           prompt: "/review-dependency-bump REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}"


### PR DESCRIPTION
Allow renovate bot to be used for dependency reviews