### PR TITLE
Add reusable Release and Promote workflows

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -1,0 +1,47 @@
+---
+name: promote
+
+on:
+  workflow_call:
+    inputs:
+      product-name:
+        description: >-
+          Optional human-readable product name prefixed to the release title.
+          When empty (default) the title is the tag alone (e.g. v1.2.3): the
+          repository already provides context in the GitHub UI. Set it for
+          monorepos or when the product name differs from the repo name
+          (e.g. "MetalK8s") to produce "MetalK8s v1.2.3".
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    # Guard against a caller invoking this workflow outside a tag push
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      # Needed by action-gh-release to create the GitHub Release. The calling
+      # job must grant at least `contents: write` as well: a called workflow
+      # can only downgrade the caller's permissions, never elevate them.
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          # NOTE: We explicitly set the refs otherwise the tag
+          # annotations content is not fetched
+          # See: https://github.com/actions/checkout/issues/882
+          ref: ${{ github.ref }}
+
+      - uses: softprops/action-gh-release@v3
+        with:
+          name: ${{ inputs.product-name && format('{0} {1}', inputs.product-name, github.ref_name) || github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          generate_release_notes: true
+          # We consider pre-releases if the tag contains a hyphen
+          # e.g. v1.2.3-alpha.0
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          draft: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,147 @@
+---
+name: release
+
+on:
+  workflow_call:
+    inputs:
+      version-type:
+        description: "Version type: alpha, beta or GA"
+        required: true
+        type: string
+      version-scope:
+        description: "Version scope: patch, minor or major"
+        required: true
+        type: string
+      product-name:
+        description: >-
+          Optional human-readable product name prefixed to the tag annotation
+          message. When empty (default) the annotation is the tag alone.
+        required: false
+        type: string
+        default: ""
+      allowed-branch:
+        description: "Only ref allowed to cut releases"
+        required: false
+        type: string
+        default: main
+      actions-app-id:
+        description: >-
+          GitHub App ID used to push the tag (usually vars.ACTIONS_APP_ID).
+          Required unless dry-run is set.
+        required: false
+        type: string
+      dry-run:
+        description: "Compute and validate the tag without pushing it"
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      ACTIONS_APP_PRIVATE_KEY:
+        description: "Private key of the GitHub App. Required unless dry-run is set."
+        required: false
+    outputs:
+      tag:
+        description: "The release tag (e.g. v1.2.3 or v1.2.3-alpha.1)"
+        value: ${{ jobs.prepare-version.outputs.tag }}
+
+# The tag is created and pushed with the GitHub App token; the default
+# GITHUB_TOKEN only needs to read the repository.
+permissions:
+  contents: read
+
+jobs:
+  prepare-version:
+    runs-on: ubuntu-latest
+    if: github.ref_name == inputs.allowed-branch
+    outputs:
+      tag: ${{ steps.compose.outputs.tag }}
+    steps:
+      - name: Validate inputs
+        env:
+          VERSION_TYPE: ${{ inputs.version-type }}
+          VERSION_SCOPE: ${{ inputs.version-scope }}
+          APP_ID: ${{ inputs.actions-app-id }}
+          DRY_RUN: ${{ inputs.dry-run }}
+        run: |
+          case "$VERSION_TYPE" in
+            alpha|beta|GA) ;;
+            *) echo "::error::invalid version-type '$VERSION_TYPE' (expected alpha, beta or GA)"; exit 1 ;;
+          esac
+          case "$VERSION_SCOPE" in
+            patch|minor|major) ;;
+            *) echo "::error::invalid version-scope '$VERSION_SCOPE' (expected patch, minor or major)"; exit 1 ;;
+          esac
+          if [[ "$DRY_RUN" != "true" && -z "$APP_ID" ]]; then
+            echo "::error::actions-app-id is required unless dry-run is set"; exit 1
+          fi
+
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        # NOTE: The tag must be pushed with an App token: tags pushed with the
+        # default GITHUB_TOKEN do not trigger the `on: push: tags` workflows
+        # (e.g. promote.yaml) in the calling repository.
+        if: ${{ !inputs.dry-run }}
+        with:
+          app-id: ${{ inputs.actions-app-id }}
+          private-key: ${{ secrets.ACTIONS_APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token || github.token }}
+
+      - name: Install semver tool
+        run: |
+          curl --fail -LO https://raw.githubusercontent.com/fsaintjacques/semver-tool/3.4.0/src/semver
+          chmod +x ./semver
+
+      - name: Compose release tag
+        id: compose
+        # `--merged HEAD` scopes tag selection to the current branch's history,
+        # and `--sort=version:refname` orders by semantic version (not creation
+        # date), so a hotfix tagged out of order on another release line can
+        # never be picked as the base version.
+        env:
+          VERSION_TYPE: ${{ inputs.version-type }}
+          VERSION_SCOPE: ${{ inputs.version-scope }}
+        run: |
+          # `|| true`: grep exits 1 when no GA tag matches (first release, or
+          # only pre-release tags); let the 0.0.0 fallback below handle it.
+          last_ga_tag=$(git tag --merged HEAD --sort=version:refname --list "v*" | { grep -v '\-' || true; } | tail -n 1)
+          if [[ -z "$last_ga_tag" ]]; then
+            last_ga_tag="0.0.0"
+          fi
+
+          new_version=$(./semver bump "$VERSION_SCOPE" "$last_ga_tag")
+
+          if [[ "$VERSION_TYPE" == "alpha" ]] || [[ "$VERSION_TYPE" == "beta" ]]; then
+            last_pre_tag=$(git tag --merged HEAD --sort=version:refname --list "v$new_version-$VERSION_TYPE.*" | tail -n 1)
+            if [[ -z "$last_pre_tag" ]]; then
+              new_version=$new_version-$VERSION_TYPE.1
+            else
+              new_version=$(./semver bump prerel "$last_pre_tag")
+            fi
+          fi
+
+          if [[ "${new_version:0:1}" != "v" ]]; then
+            new_version="v$new_version"
+          fi
+
+          echo "New version: $new_version"
+          echo "RELEASE_TAG=$new_version" >> "$GITHUB_ENV"
+          echo "tag=$new_version" >> "$GITHUB_OUTPUT"
+
+      - name: Validate ${{ env.RELEASE_TAG }} tag
+        run: ./semver validate "$RELEASE_TAG"
+
+      - name: Create and push `${{ env.RELEASE_TAG }}` tag
+        if: ${{ !inputs.dry-run }}
+        env:
+          PRODUCT_NAME: ${{ inputs.product-name }}
+        run: |
+          git config --global user.email ${{ github.actor }}@scality.com
+          git config --global user.name ${{ github.actor }}
+
+          git tag -a "$RELEASE_TAG" -m "${PRODUCT_NAME:+$PRODUCT_NAME }$RELEASE_TAG"
+          git push origin "$RELEASE_TAG"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,3 +35,26 @@ jobs:
 
   lfs-warning:
     uses: ./.github/workflows/lfs-warning.yaml
+
+  release-dry-run:
+    uses: ./.github/workflows/release.yaml
+    with:
+      version-type: alpha
+      version-scope: patch
+      # PR CI runs on a merge ref, not `main`; align the guard so the job runs
+      allowed-branch: ${{ github.ref_name }}
+      dry-run: true
+
+  release-dry-run-check:
+    needs: release-dry-run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assert a tag was computed
+        env:
+          TAG: ${{ needs.release-dry-run.outputs.tag }}
+        run: |
+          if [[ -z "$TAG" ]]; then
+            echo "::error::release dry-run produced an empty tag output"
+            exit 1
+          fi
+          echo "computed tag: $TAG"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ This is **scality/workflows**, a repository of reusable GitHub Actions workflows
 | `docker-build.yaml` | Build and push Docker images with Buildx, caching, multi-platform support |
 | `trivy.yaml` | Container vulnerability scanning, uploads SARIF to GitHub Security tab |
 | `lfs-warning.yaml` | Validates file sizes in PRs, warns about files not tracked by Git LFS |
+| `release.yaml` | Computes the next semver off the last GA tag and pushes an annotated `v*` tag |
+| `promote.yaml` | Creates a GitHub Release from a pushed `v*` tag (pre-release on hyphenated tags) |
 | `claude-code-review.yml` | AI-powered PR review via Vertex AI |
 
 ## Conventions

--- a/docs/release-promote.md
+++ b/docs/release-promote.md
@@ -1,0 +1,163 @@
+# Release & Promote
+
+`release.yaml` and `promote.yaml` are a pair of workflows automating the
+release flow of a repository:
+
+1. **Release**: triggered manually (`workflow_dispatch` in the caller).
+   Computes the next semantic version off the last GA tag reachable from the
+   current branch, then creates and pushes an annotated `v*` tag using the
+   GitHub App token.
+2. **Promote**: triggered by the `v*` tag push in the caller. Creates a
+   GitHub Release with generated notes, marked as pre-release when the tag
+   contains a hyphen (e.g. `v1.2.3-alpha.1`). The release title is the tag
+   itself (e.g. `v1.2.3`): the repository already provides context in the
+   GitHub UI; set `product-name` to prefix it (e.g. `MetalK8s v1.2.3`).
+
+Flow: click *Release* → tag is pushed → *Promote* fires → GitHub Release
+published.
+
+!!! note
+    The tag must be pushed with a GitHub App token: tags pushed with the
+    default `GITHUB_TOKEN` do not trigger `on: push: tags` workflows, so
+    Promote would never fire. This is why `release.yaml` requires
+    `actions-app-id` and the `ACTIONS_APP_PRIVATE_KEY` secret.
+
+## Usage
+
+### Release
+
+```yaml
+# release.yaml (caller)
+name: Release
+run-name: Release new ${{ inputs.version-type }} from ${{ github.ref_name }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version-type:
+        description: "Version type"
+        required: true
+        type: choice
+        default: "alpha"
+        options: ["alpha", "beta", "GA"]
+      version-scope:
+        description: "Version scope"
+        required: true
+        type: choice
+        default: "patch"
+        options: ["patch", "minor", "major"]
+
+jobs:
+  # Optional but recommended for libraries: releases are cut from `main`
+  # without re-running pre-merge, and for a Go library the tag *is* the
+  # artifact: this is the only verification point.
+  quality-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - run: go test -v ./...
+
+  release:
+    needs: quality-gate
+    uses: scality/workflows/.github/workflows/release.yaml@v2
+    with:
+      version-type: ${{ inputs.version-type }}
+      version-scope: ${{ inputs.version-scope }}
+      actions-app-id: ${{ vars.ACTIONS_APP_ID }}
+    secrets: inherit
+```
+
+`workflow_call` does not support `type: choice`, so the choice inputs live in
+the caller's `workflow_dispatch` and are relayed as strings; the reusable
+workflow validates them.
+
+### Promote
+
+```yaml
+# promote.yaml (caller)
+name: Promote
+run-name: "Promote ${{ github.ref_name }}"
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  create-release:
+    uses: scality/workflows/.github/workflows/promote.yaml@v2
+    permissions:
+      contents: write
+```
+
+For a **deployable service**, chain the image build before the release
+creation so a broken build blocks the GitHub Release:
+
+```yaml
+jobs:
+  build:
+    uses: ./.github/workflows/build.yaml
+    secrets: inherit
+    with:
+      is-development: false
+      is-latest: true
+      is-stable: ${{ ! contains(github.ref_name, '-') }}
+
+  create-release:
+    needs: build
+    uses: scality/workflows/.github/workflows/promote.yaml@v2
+    permissions:
+      contents: write
+```
+
+For a **pure library** (consumed via `go get ...@vX.Y.Z`), the tag is the
+artifact: no build job is needed.
+
+## Release inputs
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `version-type` | yes | n/a | `alpha`, `beta` or `GA` |
+| `version-scope` | yes | n/a | `patch`, `minor` or `major` |
+| `product-name` | no | _(empty)_ | Optional; prefixed to the tag annotation message when set |
+| `allowed-branch` | no | `main` | Only ref allowed to cut releases |
+| `actions-app-id` | unless `dry-run` | n/a | GitHub App ID used to push the tag |
+| `dry-run` | no | `false` | Compute and validate the tag without pushing |
+
+Secrets: `ACTIONS_APP_PRIVATE_KEY` (required unless `dry-run`).
+
+Outputs: `tag`, the computed release tag (e.g. `v1.2.3-alpha.1`).
+
+## Promote inputs
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `product-name` | no | _(empty)_ | Optional; prefixes the release title (e.g. `MetalK8s v1.2.3`) when set. Empty ⇒ the title is the tag alone (`v1.2.3`). Use it for monorepos or when the product name differs from the repo name. |
+
+The calling job must grant `permissions: contents: write`: a called workflow
+can only downgrade the caller's token permissions, never elevate them.
+
+To prefix the title, pass `product-name` from the caller:
+
+```yaml
+  create-release:
+    uses: scality/workflows/.github/workflows/promote.yaml@v2
+    permissions:
+      contents: write
+    with:
+      product-name: MetalK8s   # ⇒ "MetalK8s v1.2.3" (omit for "v1.2.3")
+```
+
+## Version computation
+
+- The base version is the highest GA tag (`v*` without hyphen) **reachable
+  from the current branch** (`git tag --merged HEAD --sort=version:refname`),
+  so a hotfix tagged out of order on another release line is never picked as
+  the base, and the computation stays correct if per-minor release branches
+  (e.g. `dev/1.0`) are introduced later.
+- `alpha`/`beta` types append or increment a pre-release suffix
+  (`v1.2.3-alpha.1`, `v1.2.3-alpha.2`, ...); `GA` produces a bare `vX.Y.Z`.
+- With no GA tag in history (first release), the base falls back to `0.0.0`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
 - Home: index.md
 - Docker build: docker-build.md
 - Trivy: trivy.md
+- Release & Promote: release-promote.md
 - Git LFS warning: lfs-warning.md
 - Known issues: known-issues.md
 


### PR DESCRIPTION
## What

Adds two reusable workflows that mutualize the release flow currently
copy-pasted across 9 repos (go-errors, crl-operator, disk-management-agent,
file-reflector, metalk8s-registry-node-agent, metalk8s-registry-operator,
prometheus-postgres-adapter, static-oci-registry, raidmgmt):

- **`release.yaml`** (`workflow_call`): computes the next semver
  (`alpha`/`beta`/`GA` × `patch`/`minor`/`major`) off the last GA tag reachable
  from the current branch and pushes an annotated `v*` tag with the GitHub App
  token. Exposes a `tag` output and a `dry-run` input.
- **`promote.yaml`** (`workflow_call`): creates a GitHub Release from a pushed
  `v*` tag, marked pre-release when the tag contains a hyphen.

Plus: `docs/release-promote.md` (library and service caller examples), a
`release-dry-run` job in `tests.yaml` exercising the version computation on
every PR, and a CLAUDE.md table update.

## Why

The `prepare-version`/`create-release` pair exists in 9 copies across the org,
so every fix means 9 PRs. This factors it into a single maintained
implementation, adapted from scality/raidmgmt#77 (itself derived from
go-errors/nodeip-discovery).

Compared to the legacy copies, this version:

- computes the base tag with `git tag --merged HEAD --sort=version:refname`
  instead of `--sort=taggerdate`: an out-of-order hotfix tag (e.g. `v1.0.1`
  tagged after `v2.0.0`) can never be picked as the base version, and the
  computation stays correct if per-minor release branches (`dev/X.Y`) are
  introduced;
- guards the GA-tag grep (`|| true`) so the `0.0.0` fallback fires on a repo
  with no GA tag yet;
- declares explicit token permissions (`contents: read` in release,
  `contents: write` in promote);
- validates `version-type`/`version-scope` at runtime (`workflow_call` cannot
  express `type: choice`, so the choices stay in the callers'
  `workflow_dispatch`);
- adds `dry-run` (compute and validate without pushing), which makes the
  workflow testable in PR CI;
- drops the `git fsck`/`git gc` calls, pointless on a fresh CI clone.

## Design notes

- **The release title is the tag alone** (e.g. `v1.2.3`): the repository already
  provides context in the GitHub UI, so the title is not prefixed with the repo
  name by default. `product-name` is an optional input that prefixes both the
  release title and the tag annotation (e.g. `product-name: MetalK8s` →
  `MetalK8s v1.2.3`), useful for monorepos or when the product name differs
  from the repository name.
- The tag **must** be pushed with an App token: tags pushed with the default
  `GITHUB_TOKEN` do not trigger `on: push: tags`, so Promote would never fire.
  `actions-app-id` is an explicit input; `ACTIONS_APP_PRIVATE_KEY` is passed via
  `secrets: inherit`.
- Promote only creates the GitHub Release. A service chains its image build in
  the caller (`needs: build`) so a broken build still blocks the release; a pure
  library calls Promote directly: the tag is the artifact.
- Quality gates (tests before tagging) stay in the callers: a library gates on
  `go test`, a service may gate differently.
- Action pins follow this repo's convention (major version tags), not the SHA
  pins used in product repos.

## Migration plan (follow-up PRs, not in this PR)

1. Tag `v2.9.0`.
2. 9 mechanical PRs replacing the local copies (roughly -80/+15 lines each). The
   `taggerdate` fix lands with the migration, no separate backport needed.
3. Later, optional: converge the 5 `platform-*` repos (currently
   release-published → test *after* publication) onto the same pair.
